### PR TITLE
Refactor: 댓글 조회 로직 리팩토링

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -45,13 +45,10 @@ const authInstance = axios.create({
 });
 
 export const getNewAccessToken = async (accessToken: string, refreshToken: string) => {
-  const response = await authInstance.post<RefreshTokenResponse>(
-    `${ENDPOINTS.refreshToken}`,
-    { accessToken, refreshToken },
-    {
-      headers: { Authorization: `Bearer ${refreshToken}` },
-    }
-  );
+  const response = await authInstance.post<RefreshTokenResponse>(`${ENDPOINTS.refreshToken}`, {
+    accessToken,
+    refreshToken,
+  });
   return response.data;
 };
 

--- a/src/pages/articleDetail/components/comment/ChildComments.module.scss
+++ b/src/pages/articleDetail/components/comment/ChildComments.module.scss
@@ -1,3 +1,23 @@
 .childCommentWrapper {
   padding-left: 1rem;
 }
+
+.loadingSpinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid #c1c1c1;
+  border-top: 2px solid transparent;
+  border-radius: 50%;
+  margin-left: 1rem;
+
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/pages/articleDetail/components/comment/ChildComments.tsx
+++ b/src/pages/articleDetail/components/comment/ChildComments.tsx
@@ -6,9 +6,13 @@ interface ChildCommentsProps {
 }
 
 const ChildComments = ({ parentCommentId }: ChildCommentsProps) => {
-  const { data } = useChildComments(parentCommentId);
+  const { data, isLoading } = useChildComments(parentCommentId);
 
   const childComments = data?.pages.flatMap((page) => page.comments);
+
+  if (isLoading) {
+    return <div className={styles.loadingSpinner} />;
+  }
 
   return (
     <div className={styles.childCommentWrapper}>


### PR DESCRIPTION
## 내용
- 댓글 조회 API 변경으로 인한 프론트 로직 수정

## 참고 사항
- 댓글과 대댓글 분리
- 대댓글 로딩 스피너 추가

## 스크린샷
![Mar-29-2024 16-58-56](https://github.com/boocam-project/FastTime-front/assets/123650056/30b6e23e-ddb6-4e56-aea1-df1092c58693)

## 이슈번호
close #121 